### PR TITLE
Make replacement in status output string global

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -90,7 +90,7 @@ const NordVPN = new Lang.Class({
 			let status = {};
 			stdout.split('\n').map(item => {
 				item = item.split(': ');
-				item[0] = item[0].replace('\r-\r  \r', ''); // a dash is send to stdout before showing info, this needs to be removed
+				item[0] = item[0].replace(/\r-\r  \r/g, ''); // a dash is send to stdout before showing info, this needs to be removed
 				status[item[0]] = item[1];
 			});
 


### PR DESCRIPTION
The first line of the `nordvpn status` turned out to be `"\r-\r  \r\r-\r
\rStatus"` on my machine. For this purpose, make the `String.replace`
call global, to replace all occurences of the substring.